### PR TITLE
Added some useful method when working with breadcrum

### DIFF
--- a/MvcBreadCrumbs/BreadCrumb.cs
+++ b/MvcBreadCrumbs/BreadCrumb.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 
@@ -6,7 +8,6 @@ namespace MvcBreadCrumbs
 {
     public class BreadCrumb
     {
-
         private static IProvideBreadCrumbsSession _SessionProvider { get; set; }
 
         private static IProvideBreadCrumbsSession SessionProvider
@@ -44,6 +45,28 @@ namespace MvcBreadCrumbs
         public static void Clear()
         {
             StateManager.RemoveState(SessionProvider.SessionId);
+        }
+
+        public static StateEntry GetCurrentUrl()
+        {
+            return StateManager.GetState(SessionProvider.SessionId).Current;
+        }
+
+        public static IEnumerable<string> GetBreadcrumOrderedUrls()
+        {
+            return StateManager.GetState(SessionProvider.SessionId).Crumbs.Select(s=>s.Url);
+        }
+
+        public static string GetPreviousUrl()
+        {
+            var previousPage = StateManager.GetState(SessionProvider.SessionId).Crumbs;
+            var updatedList = new List<StateEntry>(previousPage);
+            updatedList.Reverse();
+
+            if(updatedList.Count>1)
+                return updatedList.Skip(1).First().Url;
+
+            return null;
         }
 
         public static string Display()

--- a/MvcBreadCrumbs/BreadCrumb.cs
+++ b/MvcBreadCrumbs/BreadCrumb.cs
@@ -47,9 +47,9 @@ namespace MvcBreadCrumbs
             StateManager.RemoveState(SessionProvider.SessionId);
         }
 
-        public static StateEntry GetCurrentUrl()
+        public static string GetCurrentUrl()
         {
-            return StateManager.GetState(SessionProvider.SessionId).Current;
+            return StateManager.GetState(SessionProvider.SessionId).Current.Url;
         }
 
         public static IEnumerable<string> GetBreadcrumOrderedUrls()

--- a/MvcBreadCrumbs/BreadCrumb.cs
+++ b/MvcBreadCrumbs/BreadCrumb.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Web.Mvc;
 
 namespace MvcBreadCrumbs
 {
@@ -47,16 +48,19 @@ namespace MvcBreadCrumbs
             StateManager.RemoveState(SessionProvider.SessionId);
         }
 
+        /// <summary>
+        /// Get the currently active URL from the BreadCrumb
+        /// </summary>
+        /// <returns>The currently active URL from the BreadCrumb</returns>
         public static string GetCurrentUrl()
         {
             return StateManager.GetState(SessionProvider.SessionId).Current.Url;
         }
 
-        public static IEnumerable<string> GetBreadCrumOrderedUrls()
-        {
-            return StateManager.GetState(SessionProvider.SessionId).Crumbs.Select(s=>s.Url);
-        }
-
+        /// <summary>
+        /// Get the URL of the preceeding item from the BreadCrumb
+        /// </summary>
+        /// <returns>The URL of the preceeding item in the breadcrumb</returns>
         public static string GetPreviousUrl()
         {
             var previousPage = StateManager.GetState(SessionProvider.SessionId).Crumbs;
@@ -67,6 +71,43 @@ namespace MvcBreadCrumbs
                 return updatedList.Skip(1).First().Url;
 
             return null;
+        }
+
+        /// <summary>
+        /// Get the full list of URL currently in the breadcrumb. Index 0 being the farthest page.
+        /// </summary>
+        /// <returns>The full list of URL currently in the breadcrumb</returns>
+        public static IEnumerable<string> GetOrderedUrls()
+        {
+            return StateManager.GetState(SessionProvider.SessionId).Crumbs.Select(s => s.Url);
+        }
+
+        /// <summary>
+        /// Redirects
+        /// </summary>
+        /// <returns></returns>
+        public static RedirectResult RedirectToPreviousUrl()
+        {
+            var previousPage = StateManager.GetState(SessionProvider.SessionId).Crumbs;
+            var updatedList = new List<StateEntry>(previousPage);
+            updatedList.Reverse();
+
+            if (updatedList.Count > 1)
+            {
+                if (string.IsNullOrEmpty(updatedList.Skip(1).First().Url))
+                    return new RedirectResult(updatedList.Skip(1).First().Url);
+            }
+                
+            return null;
+        }
+
+        /// <summary>
+        /// Get the full list of <see cref="RedirectResult"/> currently in the breadcrumb. Index 0 being the farthest page.
+        /// </summary>
+        /// <returns>The full list of <see cref="RedirectResult"/> currently in the breadcrumb</returns>
+        public static IEnumerable<RedirectResult> GetOrderedRedirections()
+        {
+            return StateManager.GetState(SessionProvider.SessionId).Crumbs.Select(s => new RedirectResult(s.Url));
         }
 
         public static string Display()

--- a/MvcBreadCrumbs/BreadCrumb.cs
+++ b/MvcBreadCrumbs/BreadCrumb.cs
@@ -52,7 +52,7 @@ namespace MvcBreadCrumbs
             return StateManager.GetState(SessionProvider.SessionId).Current.Url;
         }
 
-        public static IEnumerable<string> GetBreadcrumOrderedUrls()
+        public static IEnumerable<string> GetBreadCrumOrderedUrls()
         {
             return StateManager.GetState(SessionProvider.SessionId).Crumbs.Select(s=>s.Url);
         }


### PR DESCRIPTION
When working with more complex navigation, it is sometimes useful to get the previous breadcrum item, which we might want to go back to (instead of just using the previous page or the referer).

These new methods allows one to get a glimpse of the urls currently in the breadcrum.
