### PR TITLE
Changed the key for pushing items into state 

### DIFF
--- a/MvcBreadCrumbs/BreadCrumb.cs
+++ b/MvcBreadCrumbs/BreadCrumb.cs
@@ -151,7 +151,7 @@ namespace MvcBreadCrumbs
         private static bool IsCurrentPage(int compareKey)
         {
             var key =
-                System.Web.HttpContext.Current.Request.Url.ToString()
+                System.Web.HttpContext.Current.Request.Url.LocalPath
                 .ToLower()
                 .GetHashCode();
             return key == compareKey;

--- a/MvcBreadCrumbs/State.cs
+++ b/MvcBreadCrumbs/State.cs
@@ -21,7 +21,7 @@ namespace MvcBreadCrumbs
         {
 
             var key =
-                context.HttpContext.Request.Url.ToString()
+                context.HttpContext.Request.Url.LocalPath
                 .ToLower()
                 .GetHashCode();
 


### PR DESCRIPTION
If I manually add an item to the stack like this:

BreadCrumb.Clear();
BreadCrumb.Add(Url.Action("SomeAction", "Home"), "NewRoot”);

And SomeAction has the BreadCrumb attribute, the label will appear twice in the breadcrumb trail. This is because manually adding it this way doesn’t include a domain, whereas the attribute does and therefore they will get different HashCodes. 

For example:

http://localhost/Home/SomeAction
/Home/SomeAction
