### PR TITLE
Order the crumbs to show the current at the end

### DIFF
--- a/MvcBreadCrumbs/BreadCrumb.cs
+++ b/MvcBreadCrumbs/BreadCrumb.cs
@@ -120,15 +120,15 @@ namespace MvcBreadCrumbs
 
             StringBuilder sb = new StringBuilder();
             sb.Append("<ol class=\"breadcrumb\">");
-            state.Crumbs.ForEach(x =>
+            state.Crumbs.Select(x => new { Entry = x, IsCurrent = IsCurrentPage(x.Key) }).OrderBy(x => x.IsCurrent).ToList().ForEach(x =>
             {
-                if (IsCurrentPage(x.Key))
+                if (x.IsCurrent)
                 {
-                    sb.Append("<li class='active'>" + x.Label + "</li>");
+                    sb.Append("<li class='active'>" + x.Entry.Label + "</li>");
                 }
                 else
                 {
-                    sb.Append("<li><a href=\"" + x.Url + "\">" + x.Label + "</a></li>");
+                    sb.Append("<li><a href=\"" + x.Entry.Url + "\">" + x.Entry.Label + "</a></li>");
                 }
             });
             sb.Append("</ol>");


### PR DESCRIPTION
Usually the current location is displayed as the last item of the breadcrumbs but the Display method assumes that the current is always the first Item when you programmatically add (BreadCrumb.Add() method) itens and sets a label for the current item.

```
            // Sample code that shows the "Current Page" as breadcrumb's first item
            BreadCrumb.Add(Url.Action("Index", "Home"), "Home");
            BreadCrumb.Add(Url.Action("SubSection", "Home"), "Other");
            BreadCrumb.SetLabel("Current Page");
```
