### PR TITLE
Update ResourceHelper.cs

### DIFF
--- a/MvcBreadCrumbs/ResourceHelper.cs
+++ b/MvcBreadCrumbs/ResourceHelper.cs
@@ -31,7 +31,9 @@ namespace MvcBreadCrumbs
                 return (string)property.GetValue(null, null);
             }
 
-            return resourceName ?? string.Empty;
+            //return resourceName ?? string.Empty;
+            //returning empty string from GetResourceLookup fails the null check inside WithLabel Method.Asad[09-03-2017]
+            return resourceName;
         }
     }
 }


### PR DESCRIPTION
[BreadCrumb] attribute placed on controller class does not generate automatic labels from actions.
returning empty string from GetResourceLookup fails the null check inside WithLabel Method. Fixed it, please merge with main repository. 